### PR TITLE
nfs-get: handle "nfs://" URLs with port number and quick optim

### DIFF
--- a/nfs-get.py
+++ b/nfs-get.py
@@ -44,7 +44,7 @@ def main():
 
     o = urlparse(nfs_path)
 
-    host = o.netloc
+    host = o.hostname
     uri = o.path
 
     portmapper_port = 111
@@ -63,6 +63,7 @@ def main():
             mount_path = mountpoint["path"]
             file_handle = mount.mnt(mountpoint["path"])["file_handle"]
             file_type = 2
+            break
 
     if file_handle == None:
         mount.disconnect()


### PR DESCRIPTION
rpc-scan generates "nfs://" URLs with the port number in it, ex:
```
# ./rpc-scan.py --nfs  10.0.0.1
rpc://10.0.0.1:111	Portmapper
nfs://10.0.0.1:2049/test/
[...]
```

Then if we use those URLs with nfs-get it fails because "o.netloc" = "10.0.0.1:2049" which isn't a valid host