### PR TITLE
rpc: handle denied replies

### DIFF
--- a/lib/rpc.py
+++ b/lib/rpc.py
@@ -104,16 +104,25 @@ class RPC(object):
                 data += response[4:]
 
             rpc = data[:24]
+            # parse the beginning of the reply body
             (
                 rpc_XID,
                 rpc_Message_Type,
                 rpc_Reply_State,
+            ) = struct.unpack('!LLL', rpc[:12])
+
+            if rpc_Message_Type != 1 or rpc_Reply_State != 0:
+                raise Exception("RPC protocol error")
+
+            # parse the remaining only if it is an accepted reply (rpc_Reply_State=0),
+            # because it does not exist otherwise
+            (
                 rpc_Verifier_Flavor,
                 rpc_Verifier_Length,
                 rpc_Accept_State
-            ) = struct.unpack('!LLLLLL', rpc)
+            ) = struct.unpack('!LLL', rpc[12:])
 
-            if rpc_Message_Type != 1 or rpc_Reply_State != 0 or rpc_Accept_State != 0:
+            if rpc_Accept_State != 0:
                 raise Exception("RPC protocol error")
 
             data = data[24:]


### PR DESCRIPTION
RPC reply bodies can be either MSG_ACCEPTED or MSG_DENIED:
https://www.rfc-editor.org/rfc/rfc1831.html#page-11

MSG_ACCEPTED are 24 bytes long (6 fields of 4 bytes):
![image](https://user-images.githubusercontent.com/550823/65790597-48713700-e160-11e9-975a-3505a053fb76.png)
This is correctly handled by current code.

MSG_DENIED however are shorter, 20 bytes (5 fields of 4 bytes):
![image](https://user-images.githubusercontent.com/550823/65790680-75254e80-e160-11e9-9c86-114e9d0a5f0e.png)

So `struct.unpack('!LLLLLL', rpc)` fails on MSG_DENIED replies (not enough data to unpack).
The proposed patch only unpacks the first 3 fields, checks if it's a MSG_DENIED and exits then, then only unpack the rest if it's a MSG_ACCEPTED
This is similar to this: https://github.com/nmap/nmap/blob/1ae88d2620a31639018e649c5353fa4b24387262/nselib/rpc.lua#L389